### PR TITLE
Send metadata with the cpu report

### DIFF
--- a/SDK/SDK.xcodeproj/project.pbxproj
+++ b/SDK/SDK.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		4909F5C61ED713AA00825B0B /* ReportScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 4909F5C41ED713AA00825B0B /* ReportScheduler.m */; };
 		4909F5CE1ED72A1D00825B0B /* DIContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 4909F5CC1ED72A1D00825B0B /* DIContainer.h */; };
 		4909F5CF1ED72A1D00825B0B /* DIContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 4909F5CD1ED72A1D00825B0B /* DIContainer.m */; };
+		4909F5D31ED73AA900825B0B /* TimeProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 4909F5D11ED73AA900825B0B /* TimeProvider.h */; };
+		4909F5D41ED73AA900825B0B /* TimeProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 4909F5D21ED73AA900825B0B /* TimeProvider.m */; };
 		4978C0771ED5E71400148A4E /* ReportApiClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 4978C0731ED5E71400148A4E /* ReportApiClient.h */; };
 		4978C0781ED5E71400148A4E /* ReportApiClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 4978C0741ED5E71400148A4E /* ReportApiClient.m */; };
 		4978C0791ED5E71400148A4E /* Reports.h in Headers */ = {isa = PBXBuildFile; fileRef = 4978C0751ED5E71400148A4E /* Reports.h */; };
@@ -84,6 +86,8 @@
 		4909F5CB1ED726AB00825B0B /* Configuration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Configuration.h; sourceTree = "<group>"; };
 		4909F5CC1ED72A1D00825B0B /* DIContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DIContainer.h; sourceTree = "<group>"; };
 		4909F5CD1ED72A1D00825B0B /* DIContainer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DIContainer.m; sourceTree = "<group>"; };
+		4909F5D11ED73AA900825B0B /* TimeProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TimeProvider.h; sourceTree = "<group>"; };
+		4909F5D21ED73AA900825B0B /* TimeProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TimeProvider.m; sourceTree = "<group>"; };
 		4978C0731ED5E71400148A4E /* ReportApiClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReportApiClient.h; sourceTree = "<group>"; };
 		4978C0741ED5E71400148A4E /* ReportApiClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReportApiClient.m; sourceTree = "<group>"; };
 		4978C0751ED5E71400148A4E /* Reports.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Reports.h; sourceTree = "<group>"; };
@@ -195,6 +199,15 @@
 			path = Scheduler;
 			sourceTree = "<group>";
 		};
+		4909F5D01ED737E100825B0B /* Time */ = {
+			isa = PBXGroup;
+			children = (
+				4909F5D11ED73AA900825B0B /* TimeProvider.h */,
+				4909F5D21ED73AA900825B0B /* TimeProvider.m */,
+			);
+			path = Time;
+			sourceTree = "<group>";
+		};
 		4978C0641ED5C36800148A4E /* Reporter */ = {
 			isa = PBXGroup;
 			children = (
@@ -264,6 +277,7 @@
 				4909F5AD1ED6EA9C00825B0B /* Infrastructure */,
 				4978C0641ED5C36800148A4E /* Reporter */,
 				4909F5C21ED7139800825B0B /* Scheduler */,
+				4909F5D01ED737E100825B0B /* Time */,
 				4978C0861ED5EFCB00148A4E /* FlowUp.h */,
 				4978C0871ED5EFCB00148A4E /* FlowUp.m */,
 			);
@@ -313,6 +327,7 @@
 				4909F5C01ED70E9E00825B0B /* UuidGenerator.h in Headers */,
 				4978C0881ED5EFCB00148A4E /* FlowUp.h in Headers */,
 				4909F5BC1ED7090E00825B0B /* Device.h in Headers */,
+				4909F5D31ED73AA900825B0B /* TimeProvider.h in Headers */,
 				4978C0791ED5E71400148A4E /* Reports.h in Headers */,
 				4978C07E1ED5E7E600148A4E /* CpuMetric.h in Headers */,
 				4909F5CE1ED72A1D00825B0B /* DIContainer.h in Headers */,
@@ -516,6 +531,7 @@
 				4909F5BD1ED7090E00825B0B /* Device.m in Sources */,
 				4978C0891ED5EFCB00148A4E /* FlowUp.m in Sources */,
 				4978C07F1ED5E7E600148A4E /* CpuMetric.m in Sources */,
+				4909F5D41ED73AA900825B0B /* TimeProvider.m in Sources */,
 				4978C0851ED5EC0100148A4E /* ApiClient.m in Sources */,
 				4978C07A1ED5E71400148A4E /* Reports.m in Sources */,
 				4909F5CF1ED72A1D00825B0B /* DIContainer.m in Sources */,

--- a/SDK/SDK/Device/Device.h
+++ b/SDK/SDK/Device/Device.h
@@ -14,11 +14,14 @@
 @interface Device : NSObject
 
 @property (readonly, nonatomic, copy) NSString *appPackage;
+@property (readonly, nonatomic, copy) NSString *appVersionName;
+@property (readonly, nonatomic, copy) NSString *osVersion;
 @property (readonly, nonatomic, copy) NSString *installationUuid;
 @property (readonly, nonatomic, copy) NSString *deviceModel;
 @property (readonly, nonatomic, copy) NSString *screenDensity;
 @property (readonly, nonatomic, copy) NSString *screenSize;
 @property (readonly, nonatomic) NSInteger numberOfCores;
+@property (readonly, nonatomic) BOOL isLowPowerModeEnabled;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithUuidGenerator:(UuidGenerator *)uuidGenerator;

--- a/SDK/SDK/Device/Device.m
+++ b/SDK/SDK/Device/Device.m
@@ -31,6 +31,19 @@
     return [[NSBundle mainBundle] bundleIdentifier];
 }
 
+- (NSString *)appVersionName
+{
+    return [NSString stringWithFormat:@"%@ [%@]",
+            [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
+            [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey]];
+
+}
+
+- (NSString *)osVersion
+{
+    return [[UIDevice currentDevice] systemVersion];
+}
+
 - (NSString *)installationUuid
 {
     return self.uuidGenerator.uuid;
@@ -61,6 +74,11 @@
 - (NSInteger)numberOfCores
 {
     return [[NSProcessInfo processInfo] processorCount];
+}
+
+- (BOOL)isIsLowPowerModeEnabled
+{
+    return [[NSProcessInfo processInfo] isLowPowerModeEnabled];
 }
 
 @end

--- a/SDK/SDK/Infrastructure/DIContainer.m
+++ b/SDK/SDK/Infrastructure/DIContainer.m
@@ -17,7 +17,8 @@
 
     dispatch_once(&onceToken, ^{
         _scheduler = [[ReportScheduler alloc] initWithDevice:[DIContainer device]
-                                             reportApiClient:[DIContainer reportApiClientWithApiKey:apiKey]];
+                                             reportApiClient:[DIContainer reportApiClientWithApiKey:apiKey]
+                                                        time:[DIContainer time]];
     });
 
     return _scheduler;
@@ -48,5 +49,9 @@
     return [[UuidGenerator alloc] init];
 }
 
++ (TimeProvider *)time
+{
+    return [[TimeProvider alloc] init];
+}
 
 @end

--- a/SDK/SDK/Scheduler/ReportScheduler.h
+++ b/SDK/SDK/Scheduler/ReportScheduler.h
@@ -10,15 +10,14 @@
 #import "Device.h"
 #import "ReportApiClient.h"
 #import "CpuUsageCollector.h"
+#import "TimeProvider.h"
 
 @interface ReportScheduler : NSObject
 
-@property (readonly, nonatomic) Device *device;
-@property (readonly, nonatomic) ReportApiClient *reportApiClient;
-
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithDevice:(Device*)device
-               reportApiClient:(ReportApiClient *)reportApiClient;
+               reportApiClient:(ReportApiClient *)reportApiClient
+                          time:(TimeProvider *)time;
 
 - (void)start;
 

--- a/SDK/SDK/Time/TimeProvider.h
+++ b/SDK/SDK/Time/TimeProvider.h
@@ -1,0 +1,16 @@
+//
+//  Time.h
+//  SDK
+//
+//  Created by Sergio Gutiérrez on 25/05/2017.
+//  Copyright © 2017 flowup. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface TimeProvider : NSObject
+
+@property (readonly, nonatomic) NSTimeInterval now;
+@property (readonly, nonatomic) NSInteger nowAsInt;
+
+@end

--- a/SDK/SDK/Time/TimeProvider.m
+++ b/SDK/SDK/Time/TimeProvider.m
@@ -1,0 +1,23 @@
+//
+//  Time.m
+//  SDK
+//
+//  Created by Sergio Gutiérrez on 25/05/2017.
+//  Copyright © 2017 flowup. All rights reserved.
+//
+
+#import "TimeProvider.h"
+
+@implementation TimeProvider
+
+- (NSTimeInterval) now
+{
+    return [[NSDate alloc] init].timeIntervalSince1970;
+}
+
+- (NSInteger) nowAsInt
+{
+    return roundf([self now]);
+}
+
+@end


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #7

### :tophat: What is the goal?

To send all the information within a CPU metric report, that means `timestamp`, `appVersion` and so on.

### How is it being implemented?

Most of the methods to retrieve those properties have been included in the `Device` class (I've been tempted to rename the class to `Installation` but I'll keep it the same as in Android if no major reason). I also created a `TimeProvider` class that we will replace at some point in tests. I didn't call it `Time` because it creates a conflict with a native class and I'm not adding prefixes so... Enjoy!

This is what a CPU metric report looks like now:

```json
{
    "cpu": [
        {
            "batterySaverOn": false,
            "consumption": 2,
            "isInBackground": false,
            "appVersionName": "1.0 [1]",
            "timestamp": 1495729536,
            "iOSVersion": "10.2.1"
        }
    ]
}
```