### PR TITLE
Add debug mode to send corresponding headers to API calls

### DIFF
--- a/Demo/Demo/AppDelegate.m
+++ b/Demo/Demo/AppDelegate.m
@@ -17,7 +17,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    [FlowUp application:application didFinishLaunchingWithOptions:launchOptions apiKey:@"NO API KEY YET :("];
+    [FlowUp application:application didFinishLaunchingWithOptions:launchOptions apiKey:@"NO API KEY YET :(" isDebugModeEnabled:YES];
     return YES;
 }
 @end

--- a/SDK/SDK.xcodeproj/project.pbxproj
+++ b/SDK/SDK.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		4909F5D81ED742DA00825B0B /* CollectorScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 4909F5D61ED742DA00825B0B /* CollectorScheduler.m */; };
 		491BECBF1EDEB3B800BB77A3 /* FUPSqlite.h in Headers */ = {isa = PBXBuildFile; fileRef = 491BECBD1EDEB3B800BB77A3 /* FUPSqlite.h */; };
 		491BECC01EDEB3B800BB77A3 /* FUPSqlite.m in Sources */ = {isa = PBXBuildFile; fileRef = 491BECBE1EDEB3B800BB77A3 /* FUPSqlite.m */; };
+		496E20DE1EE87155006196F5 /* FUPDebugModeStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 496E20DC1EE87155006196F5 /* FUPDebugModeStorage.h */; };
+		496E20DF1EE87155006196F5 /* FUPDebugModeStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 496E20DD1EE87155006196F5 /* FUPDebugModeStorage.m */; };
 		4978C0771ED5E71400148A4E /* ReportApiClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 4978C0731ED5E71400148A4E /* ReportApiClient.h */; };
 		4978C0781ED5E71400148A4E /* ReportApiClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 4978C0741ED5E71400148A4E /* ReportApiClient.m */; };
 		4978C0791ED5E71400148A4E /* Reports.h in Headers */ = {isa = PBXBuildFile; fileRef = 4978C0751ED5E71400148A4E /* Reports.h */; };
@@ -146,6 +148,8 @@
 		491BECBD1EDEB3B800BB77A3 /* FUPSqlite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FUPSqlite.h; sourceTree = "<group>"; };
 		491BECBE1EDEB3B800BB77A3 /* FUPSqlite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FUPSqlite.m; sourceTree = "<group>"; };
 		494E911B1EE183E100943D96 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		496E20DC1EE87155006196F5 /* FUPDebugModeStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FUPDebugModeStorage.h; sourceTree = "<group>"; };
+		496E20DD1EE87155006196F5 /* FUPDebugModeStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FUPDebugModeStorage.m; sourceTree = "<group>"; };
 		4978C0731ED5E71400148A4E /* ReportApiClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReportApiClient.h; sourceTree = "<group>"; };
 		4978C0741ED5E71400148A4E /* ReportApiClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReportApiClient.m; sourceTree = "<group>"; };
 		4978C0751ED5E71400148A4E /* Reports.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Reports.h; sourceTree = "<group>"; };
@@ -358,6 +362,25 @@
 			path = Storage;
 			sourceTree = "<group>";
 		};
+		496E20DA1EE87137006196F5 /* Debug */ = {
+			isa = PBXGroup;
+			children = (
+				496E20DB1EE8713E006196F5 /* Storage */,
+			);
+			name = Debug;
+			path = Debug;
+			sourceTree = "<group>";
+		};
+		496E20DB1EE8713E006196F5 /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				496E20DC1EE87155006196F5 /* FUPDebugModeStorage.h */,
+				496E20DD1EE87155006196F5 /* FUPDebugModeStorage.m */,
+			);
+			name = Storage;
+			path = Storage;
+			sourceTree = "<group>";
+		};
 		4978C0641ED5C36800148A4E /* Reporter */ = {
 			isa = PBXGroup;
 			children = (
@@ -429,6 +452,7 @@
 				4978C0801ED5EBE500148A4E /* API Client */,
 				4983806B1ED48D10003BCFB0 /* Collector */,
 				49B8DEE21EDC239700C8A9F5 /* Config */,
+				496E20DA1EE87137006196F5 /* Debug */,
 				4909F5B91ED7090400825B0B /* Device */,
 				4909F5AD1ED6EA9C00825B0B /* Infrastructure */,
 				4978C0641ED5C36800148A4E /* Reporter */,
@@ -707,6 +731,7 @@
 				4978C0771ED5E71400148A4E /* ReportApiClient.h in Headers */,
 				499DEED01EDD981400BDD763 /* AFNetworking.h in Headers */,
 				49B8DEEB1EDC246900C8A9F5 /* FUPConfigApiClient.h in Headers */,
+				496E20DE1EE87155006196F5 /* FUPDebugModeStorage.h in Headers */,
 				4909F5C51ED713AA00825B0B /* ReportScheduler.h in Headers */,
 				4909F5A71ED6C10100825B0B /* Metric.h in Headers */,
 				4909F5C01ED70E9E00825B0B /* UuidGenerator.h in Headers */,
@@ -920,6 +945,7 @@
 				4909F5A81ED6C10100825B0B /* Metric.m in Sources */,
 				499DEEED1EDD981400BDD763 /* UIRefreshControl+AFNetworking.m in Sources */,
 				49B8DEE71EDC23D400C8A9F5 /* FUPConfig.m in Sources */,
+				496E20DF1EE87155006196F5 /* FUPDebugModeStorage.m in Sources */,
 				499DEEDF1EDD981400BDD763 /* AFImageDownloader.m in Sources */,
 				49D839CD1ED81B10004F47C6 /* MetricsStorage.m in Sources */,
 				499DEED81EDD981400BDD763 /* AFURLResponseSerialization.m in Sources */,

--- a/SDK/SDK/API Client/ApiClient.h
+++ b/SDK/SDK/API Client/ApiClient.h
@@ -10,6 +10,7 @@
 #import "AFNetworking.h"
 #import "Configuration.h"
 #import "FUPApiClientError.h"
+#import "FUPDebugModeStorage.h"
 
 @interface ApiClient : NSObject
 
@@ -18,7 +19,8 @@
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithBaseUrl:(NSString *)baseUrl
                          apiKey:(NSString *)apiKey
-                           uuid:(NSString *)uuid;
+                           uuid:(NSString *)uuid
+               debugModeStorage:(FUPDebugModeStorage *)debugModeStorage;
 
 - (NSString *)urlStringWithEndpoint:(NSString *)endpoint;
 - (FUPApiClientError *)mapError:(NSError *)error;

--- a/SDK/SDK/API Client/ApiClient.m
+++ b/SDK/SDK/API Client/ApiClient.m
@@ -16,6 +16,7 @@ static NSInteger const FUPServerErrorStatusCode = 500;
 @interface ApiClient ()
 
 @property (readonly, nonatomic, copy) NSString *baseUrl;
+@property (readonly, nonatomic) FUPDebugModeStorage *debugModeStorage;
 
 @end
 
@@ -24,9 +25,11 @@ static NSInteger const FUPServerErrorStatusCode = 500;
 - (instancetype)initWithBaseUrl:(NSString *)baseUrl
                          apiKey:(NSString *)apiKey
                            uuid:(NSString *)uuid
+               debugModeStorage:(FUPDebugModeStorage *)debugModeStorage
 {
     self = [super init];
     if (self) {
+        _debugModeStorage = debugModeStorage;
         _manager = [self sessionManagerWithApiKey:apiKey uuid:uuid];
         _baseUrl = baseUrl;
     }
@@ -63,12 +66,19 @@ static NSInteger const FUPServerErrorStatusCode = 500;
     [manager.requestSerializer setValue:[self userAgent] forHTTPHeaderField:@"User-Agent"];
     [manager.requestSerializer setValue:uuid forHTTPHeaderField:@"X-UUID"];
     [manager.requestSerializer setValue:apiKey forHTTPHeaderField:@"X-Api-Key"];
+    [manager.requestSerializer setValue:self.debugModeStorage.isDebugModeEnabled ? @"true" : @"false" forHTTPHeaderField:@"X-Debug-Mode"];
     return manager;
 }
 
 - (NSString *)userAgent
 {
-    return [NSString stringWithFormat:@"FlowUpIOSSDK/%@", SDKVersion];
+    NSString *userAgent = [NSString stringWithFormat:@"FlowUpIOSSDK/%@", SDKVersion];
+
+    if (self.debugModeStorage.isDebugModeEnabled) {
+        userAgent = [userAgent stringByAppendingString:@"-DEBUG"];
+    }
+
+    return userAgent;
 }
 
 @end

--- a/SDK/SDK/Debug/Storage/FUPDebugModeStorage.h
+++ b/SDK/SDK/Debug/Storage/FUPDebugModeStorage.h
@@ -1,0 +1,15 @@
+//
+//  FUPDebugModeStorage.h
+//  SDK
+//
+//  Created by Sergio Gutiérrez on 07/06/2017.
+//  Copyright © 2017 flowup. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface FUPDebugModeStorage : NSObject
+
+@property (readwrite, nonatomic) BOOL isDebugModeEnabled;
+
+@end

--- a/SDK/SDK/Debug/Storage/FUPDebugModeStorage.m
+++ b/SDK/SDK/Debug/Storage/FUPDebugModeStorage.m
@@ -1,0 +1,13 @@
+//
+//  FUPDebugModeStorage.m
+//  SDK
+//
+//  Created by Sergio Gutiérrez on 07/06/2017.
+//  Copyright © 2017 flowup. All rights reserved.
+//
+
+#import "FUPDebugModeStorage.h"
+
+@implementation FUPDebugModeStorage
+
+@end

--- a/SDK/SDK/FlowUp.h
+++ b/SDK/SDK/FlowUp.h
@@ -14,6 +14,9 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 
-+ (void)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions apiKey:(NSString *)apiKey;
++ (void)application:(UIApplication *)application
+didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+             apiKey:(NSString *)apiKey
+ isDebugModeEnabled:(BOOL)isDebugModeEnabled;
 
 @end

--- a/SDK/SDK/FlowUp.m
+++ b/SDK/SDK/FlowUp.m
@@ -13,11 +13,16 @@
 
 static BOOL isInitialized = NO;
 
-+ (void)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions apiKey:(NSString *)apiKey
++ (void)application:(UIApplication *)application
+didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+             apiKey:(NSString *)apiKey
+ isDebugModeEnabled:(BOOL)isDebugModeEnabled
 {
     if (isInitialized) {
         return;
     }
+
+    [DIContainer debugModeStorage].isDebugModeEnabled = isDebugModeEnabled;
 
     CollectorScheduler *collectorScheduler = [DIContainer collectorScheduler];
     ReportScheduler *reportScheduler = [DIContainer reportSchedulerWithApiKey:apiKey];

--- a/SDK/SDK/Infrastructure/DIContainer.h
+++ b/SDK/SDK/Infrastructure/DIContainer.h
@@ -14,6 +14,7 @@
 #import "FUPConfigService.h"
 #import "ReportApiClient.h"
 #import "Configuration.h"
+#import "FUPDebugModeStorage.h"
 
 @interface DIContainer : NSObject
 
@@ -22,5 +23,6 @@
 + (ReportScheduler *)reportSchedulerWithApiKey:(NSString *)apiKey;
 + (FUPConfigSyncScheduler *)configSyncSchedulerWithApiKey:(NSString *)apiKey;
 + (FUPConfigStorage *)configStorage;
++ (FUPDebugModeStorage *)debugModeStorage;
 
 @end

--- a/SDK/SDK/Infrastructure/DIContainer.m
+++ b/SDK/SDK/Infrastructure/DIContainer.m
@@ -67,13 +67,26 @@
     return _storage;
 }
 
++ (FUPDebugModeStorage *)debugModeStorage
+{
+    static FUPDebugModeStorage *_storage;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+        _storage = [[FUPDebugModeStorage alloc] init];
+    });
+
+    return _storage;
+}
+
 + (FUPConfigApiClient *)configApiClientWithApiKey:(NSString *)apiKey
 {
 
     NSString *uuid = [DIContainer uuidGenerator].uuid;
     return [[FUPConfigApiClient alloc] initWithBaseUrl:ApiBaseUrl
                                                 apiKey:apiKey
-                                                  uuid:uuid];
+                                                  uuid:uuid
+                                      debugModeStorage:[DIContainer debugModeStorage]];
 }
 
 + (ReportApiClient *)reportApiClientWithApiKey:(NSString *)apiKey
@@ -81,7 +94,8 @@
     NSString *uuid = [DIContainer uuidGenerator].uuid;
     return [[ReportApiClient alloc] initWithBaseUrl:ApiBaseUrl
                                              apiKey:apiKey
-                                               uuid:uuid];
+                                               uuid:uuid
+                                   debugModeStorage:[DIContainer debugModeStorage]];
 }
 
 + (Device *)device

--- a/SDK/Tests/Config/API Client/FUPConfigApiClientTests.m
+++ b/SDK/Tests/Config/API Client/FUPConfigApiClientTests.m
@@ -15,16 +15,9 @@
 
 @interface FUPConfigApiClientTests : ApiClientTests
 
-@property (readwrite, nonatomic) FUPConfigApiClient *apiClient;
-
 @end
 
 @implementation FUPConfigApiClientTests
-
-- (void)setUp {
-    [super setUp];
-    self.apiClient = [self apiClient];
-}
 
 - (void)testApiClient_SendsAcceptJsonHeader_Always {
     stubRequest(@"GET", @"https://www.testingflowup.com/config").
@@ -32,7 +25,7 @@
     andReturn(200);
 
     __block BOOL didGetConfig = NO;
-    [self.apiClient getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { didGetConfig = YES; }];
+    [[self apiClient] getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { didGetConfig = YES; }];
 
     expect(didGetConfig).toEventually(equal(YES));
 }
@@ -43,7 +36,7 @@
     andReturn(200);
 
     __block BOOL didGetConfig = NO;
-    [self.apiClient getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { didGetConfig = YES; }];
+    [[self apiClient] getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { didGetConfig = YES; }];
 
     expect(didGetConfig).toEventually(equal(YES));
 }
@@ -54,7 +47,7 @@
     andReturn(200);
 
     __block BOOL didGetConfig = NO;
-    [self.apiClient getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { didGetConfig = YES; }];
+    [[self apiClient] getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { didGetConfig = YES; }];
 
     expect(didGetConfig).toEventually(equal(YES));
 }
@@ -65,7 +58,7 @@
     andReturn(200);
 
     __block BOOL didGetConfig = NO;
-    [self.apiClient getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { didGetConfig = YES; }];
+    [[self apiClient] getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { didGetConfig = YES; }];
 
     expect(didGetConfig).toEventually(equal(YES));
 }
@@ -76,7 +69,40 @@
     andReturn(200);
 
     __block BOOL didGetConfig = NO;
-    [self.apiClient getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { didGetConfig = YES; }];
+    [[self apiClient] getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { didGetConfig = YES; }];
+
+    expect(didGetConfig).toEventually(equal(YES));
+}
+
+- (void)testApiClient_SendsUserAgentHeaderWithDebugMode_IfDebugModeIsEnabled {
+    stubRequest(@"GET", @"https://www.testingflowup.com/config").
+    withHeader(@"User-Agent", [NSString stringWithFormat:@"FlowUpIOSSDK/%@-DEBUG", SDKVersion]).
+    andReturn(200);
+
+    __block BOOL didGetConfig = NO;
+    [[self apiClientWithDebugModeEnabled:YES] getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { didGetConfig = YES; }];
+
+    expect(didGetConfig).toEventually(equal(YES));
+}
+
+- (void)testApiClient_SendsDebugHeaderAsTrue_IfDebugModeIsEnabled {
+    stubRequest(@"GET", @"https://www.testingflowup.com/config").
+    withHeader(@"X-Debug-Mode", [NSString stringWithFormat:@"true"]).
+    andReturn(200);
+
+    __block BOOL didGetConfig = NO;
+    [[self apiClientWithDebugModeEnabled:YES] getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { didGetConfig = YES; }];
+
+    expect(didGetConfig).toEventually(equal(YES));
+}
+
+- (void)testApiClient_SendsDebugHeaderAsFalse_IfDebugModeIsDisabled {
+    stubRequest(@"GET", @"https://www.testingflowup.com/config").
+    withHeader(@"X-Debug-Mode", [NSString stringWithFormat:@"false"]).
+    andReturn(200);
+
+    __block BOOL didGetConfig = NO;
+    [[self apiClient] getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { didGetConfig = YES; }];
 
     expect(didGetConfig).toEventually(equal(YES));
 }
@@ -86,8 +112,8 @@
     withHeader(@"User-Agent", [NSString stringWithFormat:@"FlowUpIOSSDK/%@", SDKVersion]).
     andReturn(500);
 
-    __block FUPApiClientError *error = NO;
-    [self.apiClient getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { error = response.error; }];
+    __block FUPApiClientError *error = nil;
+    [[self apiClient] getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { error = response.error; }];
 
 
     expect(error).toEventuallyNot(beNil());
@@ -99,8 +125,8 @@
     withHeader(@"User-Agent", [NSString stringWithFormat:@"FlowUpIOSSDK/%@", SDKVersion]).
     andReturn(401);
 
-    __block FUPApiClientError *error = NO;
-    [self.apiClient getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { error = response.error; }];
+    __block FUPApiClientError *error = nil;
+    [[self apiClient] getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { error = response.error; }];
 
 
     expect(error).toEventuallyNot(beNil());
@@ -115,7 +141,7 @@
     withBody([self stringFromJsonFileWithName:@"getConfigResponse"]);
 
     __block FUPConfig *config = nil;
-    [self.apiClient getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { config = response.value; }];
+    [[self apiClient] getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { config = response.value; }];
 
     expect(config).toEventuallyNot(beNil());
     expect(config.isEnabled).to(beFalse());
@@ -129,7 +155,7 @@
     withBody([self stringFromJsonFileWithName:@"emptyConfigResponse"]);
 
     __block FUPConfig *config = nil;
-    [self.apiClient getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { config = response.value; }];
+    [[self apiClient] getConfigWithCompletion:^(FUPResult<FUPConfig *,FUPApiClientError *> *response) { config = response.value; }];
 
     expect(config).toEventuallyNot(beNil());
     expect(config.isEnabled).to(beTrue());
@@ -137,9 +163,17 @@
 
 - (FUPConfigApiClient *)apiClient
 {
+    return [self apiClientWithDebugModeEnabled:NO];
+}
+
+- (FUPConfigApiClient *)apiClientWithDebugModeEnabled:(BOOL)isDebugModeEnabled
+{
+    FUPDebugModeStorage *debugModeStorage = [[FUPDebugModeStorage alloc] init];
+    debugModeStorage.isDebugModeEnabled = isDebugModeEnabled;
     return [[FUPConfigApiClient alloc] initWithBaseUrl:@"https://www.testingflowup.com"
                                                 apiKey:ApiKey
-                                                  uuid:Uuid];
+                                                  uuid:Uuid
+                                      debugModeStorage:debugModeStorage];
 }
 
 @end

--- a/SDK/Tests/Reporter/API Client/ReportApiClientTests.m
+++ b/SDK/Tests/Reporter/API Client/ReportApiClientTests.m
@@ -18,16 +18,9 @@
 
 @interface ReportApiClientTests : ApiClientTests
 
-@property (readwrite, nonatomic) ReportApiClient *reportApiClient;
-
 @end
 
 @implementation ReportApiClientTests
-
-- (void)setUp {
-    [super setUp];
-    self.reportApiClient = [self reportApiClient];
-}
 
 - (void)testApiClient_SendsAcceptJsonHeader_Always {
     stubRequest(@"POST", @"https://www.testingflowup.com/report").
@@ -35,8 +28,8 @@
     andReturn(200);
 
     __block BOOL didSendReport = NO;
-    [self.reportApiClient sendReports:[self anyReports]
-                           completion:^(FUPApiClientError *error) { didSendReport = YES; }];
+    [[self apiClient] sendReports:[self anyReports]
+                       completion:^(FUPApiClientError *error) { didSendReport = YES; }];
 
     expect(didSendReport).toEventually(equal(YES));
 }
@@ -47,8 +40,8 @@
     andReturn(200);
 
     __block BOOL didSendReport = NO;
-    [self.reportApiClient sendReports:[self anyReports]
-                           completion:^(FUPApiClientError *error) { didSendReport = YES; }];
+    [[self apiClient] sendReports:[self anyReports]
+                       completion:^(FUPApiClientError *error) { didSendReport = YES; }];
 
     expect(didSendReport).toEventually(equal(YES));
 }
@@ -59,8 +52,8 @@
     andReturn(200);
 
     __block BOOL didSendReport = NO;
-    [self.reportApiClient sendReports:[self anyReports]
-                           completion:^(FUPApiClientError *error) { didSendReport = YES; }];
+    [[self apiClient] sendReports:[self anyReports]
+                       completion:^(FUPApiClientError *error) { didSendReport = YES; }];
 
     expect(didSendReport).toEventually(equal(YES));
 }
@@ -71,8 +64,8 @@
     andReturn(200);
 
     __block BOOL didSendReport = NO;
-    [self.reportApiClient sendReports:[self anyReports]
-                           completion:^(FUPApiClientError *error) { didSendReport = YES; }];
+    [[self apiClient] sendReports:[self anyReports]
+                       completion:^(FUPApiClientError *error) { didSendReport = YES; }];
 
     expect(didSendReport).toEventually(equal(YES));
 }
@@ -83,11 +76,48 @@
     andReturn(200);
 
     __block BOOL didSendReport = NO;
-    [self.reportApiClient sendReports:[self anyReports]
-                           completion:^(FUPApiClientError *error) { didSendReport = YES; }];
+    [[self apiClient] sendReports:[self anyReports]
+                       completion:^(FUPApiClientError *error) { didSendReport = YES; }];
 
     expect(didSendReport).toEventually(equal(YES));
 }
+
+- (void)testApiClient_SendsUserAgentHeaderWithDebugMode_IfDebugModeIsEnabled {
+    stubRequest(@"POST", @"https://www.testingflowup.com/report").
+    withHeader(@"User-Agent", [NSString stringWithFormat:@"FlowUpIOSSDK/%@-DEBUG", SDKVersion]).
+    andReturn(200);
+
+    __block BOOL didSendReport = NO;
+    [[self apiClientWithDebugModeEnabled:YES] sendReports:[self anyReports]
+                                               completion:^(FUPApiClientError *error) { didSendReport = YES; }];
+
+    expect(didSendReport).toEventually(equal(YES));
+}
+
+- (void)testApiClient_SendsDebugHeaderAsTrue_IfDebugModeIsEnabled {
+    stubRequest(@"POST", @"https://www.testingflowup.com/report").
+    withHeader(@"X-Debug-Mode", [NSString stringWithFormat:@"true"]).
+    andReturn(200);
+
+    __block BOOL didSendReport = NO;
+    [[self apiClientWithDebugModeEnabled:YES] sendReports:[self anyReports]
+                                               completion:^(FUPApiClientError *error) { didSendReport = YES; }];
+
+    expect(didSendReport).toEventually(equal(YES));
+}
+
+- (void)testApiClient_SendsDebugHeaderAsFalse_IfDebugModeIsDisabled {
+    stubRequest(@"POST", @"https://www.testingflowup.com/report").
+    withHeader(@"X-Debug-Mode", [NSString stringWithFormat:@"false"]).
+    andReturn(200);
+
+    __block BOOL didSendReport = NO;
+    [[self apiClient] sendReports:[self anyReports]
+                       completion:^(FUPApiClientError *error) { didSendReport = YES; }];
+
+    expect(didSendReport).toEventually(equal(YES));
+}
+
 
 - (void)testApiClient_SendReports_Always {
     stubRequest(@"POST", @"https://www.testingflowup.com/report").
@@ -95,8 +125,8 @@
     andReturn(200);
 
     __block BOOL didSendReport = NO;
-    [self.reportApiClient sendReports:[self anyReports]
-                           completion:^(FUPApiClientError *error) { didSendReport = YES; }];
+    [[self apiClient] sendReports:[self anyReports]
+                       completion:^(FUPApiClientError *error) { didSendReport = YES; }];
 
     expect(didSendReport).toEventually(equal(YES));
 }
@@ -107,8 +137,8 @@
     andReturn(200);
 
     __block BOOL success = NO;
-    [self.reportApiClient sendReports:[self anyReports]
-                           completion:^(FUPApiClientError *error) { success = error == nil; }];
+    [[self apiClient] sendReports:[self anyReports]
+                       completion:^(FUPApiClientError *error) { success = error == nil; }];
 
     expect(success).toEventually(equal(YES));
 }
@@ -119,8 +149,8 @@
     andReturn(500);
 
     __block FUPApiClientError *returnedError = nil;
-    [self.reportApiClient sendReports:[self anyReports]
-                           completion:^(FUPApiClientError *error) { returnedError = error; }];
+    [[self apiClient] sendReports:[self anyReports]
+                       completion:^(FUPApiClientError *error) { returnedError = error; }];
 
     expect(returnedError).toEventuallyNot(beNil());
     XCTAssertEqual(returnedError.code, FUPApiClientErrorCodeServerError);
@@ -132,8 +162,8 @@
     andReturn(401);
 
     __block FUPApiClientError *returnedError = nil;
-    [self.reportApiClient sendReports:[self anyReports]
-                           completion:^(FUPApiClientError *error) { returnedError = error; }];
+    [[self apiClient] sendReports:[self anyReports]
+                       completion:^(FUPApiClientError *error) { returnedError = error; }];
 
     expect(returnedError).toEventuallyNot(beNil());
     XCTAssertEqual(returnedError.code, FUPApiClientErrorCodeUnauthorized);
@@ -145,8 +175,8 @@
     andReturn(403);
 
     __block FUPApiClientError *returnedError = nil;
-    [self.reportApiClient sendReports:[self anyReports]
-                           completion:^(FUPApiClientError *error) { returnedError = error; }];
+    [[self apiClient] sendReports:[self anyReports]
+                       completion:^(FUPApiClientError *error) { returnedError = error; }];
 
     expect(returnedError).toEventuallyNot(beNil());
     XCTAssertEqual(returnedError.code, FUPApiClientErrorCodeUnauthorized);
@@ -158,19 +188,28 @@
     andReturn(412);
 
     __block FUPApiClientError *returnedError = nil;
-    [self.reportApiClient sendReports:[self anyReports]
-                           completion:^(FUPApiClientError *error) { returnedError = error; }];
+    [[self apiClient] sendReports:[self anyReports]
+                       completion:^(FUPApiClientError *error) { returnedError = error; }];
 
     expect(returnedError).toEventuallyNot(beNil());
     XCTAssertEqual(returnedError.code, FUPApiClientErrorCodeClientDisabled);
 }
 
 
-- (ReportApiClient *)reportApiClient
+- (ReportApiClient *)apiClient
 {
+    return [self apiClientWithDebugModeEnabled:NO];
+}
+
+- (ReportApiClient *)apiClientWithDebugModeEnabled:(BOOL)isDebugModeEnabled
+{
+    FUPDebugModeStorage *debugModeStorage = [[FUPDebugModeStorage alloc] init];
+    debugModeStorage.isDebugModeEnabled = isDebugModeEnabled;
+
     return [[ReportApiClient alloc] initWithBaseUrl:@"https://www.testingflowup.com"
                                              apiKey:ApiKey
-                                               uuid:Uuid];
+                                               uuid:Uuid
+                                   debugModeStorage:debugModeStorage];
 }
 
 - (Reports *)anyReports


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #14 

### :tophat: What is the goal?

Add a debug mode to the SDK so that developers can use the product right away bypassing some of the rate limits forced in server.

### How is it being implemented?

We just added a new flag parameter to the only entry point of the SDK specifying if the developer wants to use FlowUp in debug mode or not. If it is, we store that value in an in-memory storage and consume it from the API clients (config & reports for now, we don't have the crash reporter yet) adding the correct headers (`X-Debug-Mode` and `User Agent`)