### PR TITLE
Remove old metrics if we store more than N reports in db

### DIFF
--- a/SDK/SDK/Collector/Scheduler/FUPCollectorScheduler.h
+++ b/SDK/SDK/Collector/Scheduler/FUPCollectorScheduler.h
@@ -10,13 +10,13 @@
 #import "FUPCollector.h"
 #import "FUPAsync.h"
 #import "FUPSafetyNet.h"
+#import "FUPConfigService.h"
 
 @interface FUPCollectorScheduler : NSObject
 
-@property (readwrite, nonatomic) BOOL isEnabled;
-
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithSafetyNet:(FUPSafetyNet *)safetyNet;
+- (instancetype)initWithSafetyNet:(FUPSafetyNet *)safetyNet
+                    configService:(FUPConfigService *)configService;
 
 - (void)addCollectors:(NSArray<id<FUPCollector>> *)collectors
          timeInterval:(NSTimeInterval)timeInterval;

--- a/SDK/SDK/Collector/Scheduler/FUPCollectorScheduler.m
+++ b/SDK/SDK/Collector/Scheduler/FUPCollectorScheduler.m
@@ -11,6 +11,7 @@
 @interface FUPCollectorScheduler ()
 
 @property (readonly, nonatomic) FUPSafetyNet *safetyNet;
+@property (readonly, nonatomic) FUPConfigService *configService;
 @property (readonly, nonatomic) dispatch_queue_t queue;
 
 @end
@@ -18,11 +19,12 @@
 @implementation FUPCollectorScheduler
 
 - (instancetype)initWithSafetyNet:(FUPSafetyNet *)safetyNet
+                    configService:(FUPConfigService *)configService
 {
     self = [super init];
     if (self) {
         _safetyNet = safetyNet;
-        _isEnabled = YES;
+        _configService = configService;
         _queue = dispatch_queue_create("Collector Scheduler Queue", DISPATCH_QUEUE_CONCURRENT);
     }
     return self;
@@ -36,7 +38,9 @@
         [NSTimer scheduledTimerWithTimeInterval:timeInterval repeats:YES block:^(NSTimer *timer) {
             NSLog(@"[FUPCollectorScheduler] Collect");
             [self.safetyNet runBlock:^{
-                async(self.queue, ^{ [collector collect]; });
+                if (self.configService.enabled) {
+                    async(self.queue, ^{ [collector collect]; });
+                }
             }];
         }];
     }

--- a/SDK/SDK/Infrastructure/FUPDiContainer.m
+++ b/SDK/SDK/Infrastructure/FUPDiContainer.m
@@ -12,7 +12,8 @@
 
 + (FUPCollectorScheduler *)collectorSchedulerWithApiKey:(NSString *)apiKey
 {
-    return [[FUPCollectorScheduler alloc] initWithSafetyNet:[FUPDiContainer safetyNetWithApiKey:apiKey]];
+    return [[FUPCollectorScheduler alloc] initWithSafetyNet:[FUPDiContainer safetyNetWithApiKey:apiKey]
+                                              configService:[FUPDiContainer configServiceWithApiKey:apiKey]];
 }
 
 + (FUPReportScheduler *)reportSchedulerWithApiKey:(NSString *)apiKey

--- a/SDK/SDK/Reporter/Scheduler/FUPReportScheduler.m
+++ b/SDK/SDK/Reporter/Scheduler/FUPReportScheduler.m
@@ -80,7 +80,7 @@ static NSTimeInterval const NeverReported = -1;
     FUPReports *reports = [self reportsWithMetrics:metrics];
     [self.reportApiClient sendReports:reports completion:^(FUPApiClientError *error) {
         if (error == nil) {
-            NSLog(@"[ReportScheduler] Reports successfully sent [%ld]", metrics.count);
+            NSLog(@"[ReportScheduler] Reports successfully sent [%ld]", (long)metrics.count);
             [self removeReportedMetricsCount:metrics.count];
         } else if (error.code == FUPApiClientErrorCodeUnauthorized || error.code == FUPApiClientErrorCodeServerError) {
             NSLog(@"[ReportScheduler] There was an error sending the reports: Unauthorized OR Server error");

--- a/SDK/SDK/Reporter/Storage/FUPMetricsStorage.h
+++ b/SDK/SDK/Reporter/Storage/FUPMetricsStorage.h
@@ -12,6 +12,8 @@
 #import "FUPSqlite.h"
 #import "FUPMetric.h"
 #import "FUPMetricsStorageMapper.h"
+#import "FUPTimeIntervalUnits.h"
+#import "FUPConfiguration.h"
 
 @interface FUPMetricsStorage : NSObject
 

--- a/SDK/SDK/Reporter/Storage/FUPMetricsStorage.m
+++ b/SDK/SDK/Reporter/Storage/FUPMetricsStorage.m
@@ -20,7 +20,7 @@ additional_values TEXT NOT NULL)";
 
 static NSUInteger const TableVersion = 1;
 
-static NSUInteger const MaxNumberOfStoredReports = 1000;
+static NSUInteger const MaxNumberOfStoredReports = HOURS(4) / CollectorSchedulerSamplingTimeInterval;
 
 @interface FUPMetricsStorage ()
 
@@ -72,7 +72,7 @@ static NSUInteger const MaxNumberOfStoredReports = 1000;
     NSString *query = [NSString stringWithFormat:
                        @"SELECT * FROM metrics \
                        ORDER BY timestamp ASC \
-                       LIMIT %ld", numberOfCpuMetrics];
+                       LIMIT %ld", (long)numberOfCpuMetrics];
     [self.sqlite runQuery:query block:^BOOL(sqlite3_stmt *statement) {
         FUPMetric *metric = [self.mapper metricFromStatement:statement];
         if (metric != nil) {
@@ -92,7 +92,7 @@ static NSUInteger const MaxNumberOfStoredReports = 1000;
                                  WHERE _id IN ( \
                                  SELECT _id FROM metrics \
                                  ORDER BY timestamp ASC \
-                                 LIMIT %ld)", numberOfMetrics];
+                                 LIMIT %ld)", (long)numberOfMetrics];
     BOOL success = [self.sqlite runStatement:deleteStatement];
 
     if (!success) {

--- a/SDK/Tests/Reporter/Storage/FUPMetricsStorageTests.m
+++ b/SDK/Tests/Reporter/Storage/FUPMetricsStorageTests.m
@@ -132,13 +132,13 @@
 
 - (void)testMetricsStorage_NeverStoresMoreThanMaximumNumberOfReports
 {
-    for (int i = 0; i < 1001; i++) {
+    for (int i = 0; i < 1441; i++) {
         [self.storage storeMetric:[FUPMetricMother any]];
     }
 
-    NSArray<FUPMetric *> *metrics = [self.storage metricsAtMost:1001];
+    NSArray<FUPMetric *> *metrics = [self.storage metricsAtMost:1441];
 
-    expect(metrics.count).to(equal(1000));
+    expect(metrics.count).to(equal(1440));
 }
 
 @end


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #42 

### :tophat: What is the goal?

To force an upper bound in the number of reports that we store so that we don't store too many metrics and affect the storage usage of our client apps too much.

### How is it being implemented?

Whenever we insert new metrics we are now verifying if the number of metrics stored is greater than a specific value. If it is, we remove the older reports.

We are also now reporting metrics starting from the older ones instead of the newer ones.
